### PR TITLE
Fix AAPL false positive in Islamic compliance screening

### DIFF
--- a/test_main.py
+++ b/test_main.py
@@ -73,23 +73,23 @@ def test_check_business_practices():
     assert 'non_compliant_reasons' in business_practices, "non_compliant_reasons not in result"
 
 def test_aapl_business_practices_compliance(caplog):
-    """Test AAPL business practices compliance and capture debug logs"""
+    """Test AAPL business practices compliance - should be compliant after credit card keyword fix
+    
+    AAPL was previously marked non-compliant due to 'Apple Card, a co-branded credit card'
+    in its business description. After fixing the keywords to be more specific
+    ('credit card company/issuer/provider'), AAPL should now be correctly marked as compliant
+    since it's a technology company that partners with financial institutions rather than
+    being a credit card issuer itself.
+    """
     with caplog.at_level(logging.DEBUG):
         run_islamic_compliance_test(
             symbol="AAPL",
-            expected_compliance=False,
-            expected_reasons=["Company's business description indicates involvement in financial services"]
+            expected_compliance=True,
+            expected_reasons=[]
         )
     # Print captured logs
     for record in caplog.records:
         print(record.message)
-
-    """Test AAPL compliance"""
-    run_islamic_compliance_test(
-        symbol="AAPL",
-        expected_compliance=False,
-        expected_reasons=["Company's business description indicates involvement in financial services"]
-    )
 
 def test_amzn_compliance():
     """Test AMZN compliance"""

--- a/utils/islamic_screening.py
+++ b/utils/islamic_screening.py
@@ -71,16 +71,24 @@ def check_business_practices(info):
             'nightclub', 'cabaret'
         ],
         'financial services': [
-            'commercial bank', 'investment bank', 'mortgage', 'credit services',
-            # Note: Using specific credit card terms instead of generic 'credit card' to avoid
-            # false positives with tech companies that offer payment products (e.g., Apple Card)
-            # while still catching actual credit card issuers and financial institutions
+            # Banking and traditional financial institutions
+            'commercial bank', 'investment bank', 'retail banking', 'corporate banking',
+            'financial exchange',
+            
+            # Credit and lending services
+            'credit services', 'lending services', 'consumer lending', 'mortgage',
+            
+            # Credit card specific terms (avoiding generic 'credit card' to prevent false positives
+            # with tech companies that offer payment products like Apple Card)
             'credit card company', 'credit card issuer', 'credit card provider',
             'credit card business', 'credit card services', 'credit card processing',
-            'lending services', 'consumer lending', 'asset management', 
-            'capital markets', 'insurance', 'investment brokerage', 
-            'wealth management', 'retail banking', 'corporate banking', 
-            'financial exchange'
+            
+            # Investment and wealth management
+            'asset management', 'investment brokerage', 'wealth management',
+            'capital markets',
+            
+            # Insurance
+            'insurance'
         ]
     }
 

--- a/utils/islamic_screening.py
+++ b/utils/islamic_screening.py
@@ -72,10 +72,11 @@ def check_business_practices(info):
         ],
         'financial services': [
             'commercial bank', 'investment bank', 'mortgage', 'credit services',
-            'credit card', 'lending services', 'consumer lending',
-            'asset management', 'capital markets', 'insurance',
-            'investment brokerage', 'wealth management', 'retail banking',
-            'corporate banking', 'financial exchange'
+            'credit card company', 'credit card issuer', 'credit card provider',
+            'lending services', 'consumer lending', 'asset management', 
+            'capital markets', 'insurance', 'investment brokerage', 
+            'wealth management', 'retail banking', 'corporate banking', 
+            'financial exchange'
         ]
     }
 

--- a/utils/islamic_screening.py
+++ b/utils/islamic_screening.py
@@ -72,6 +72,9 @@ def check_business_practices(info):
         ],
         'financial services': [
             'commercial bank', 'investment bank', 'mortgage', 'credit services',
+            # Note: Using specific credit card terms instead of generic 'credit card' to avoid
+            # false positives with tech companies that offer payment products (e.g., Apple Card)
+            # while still catching actual credit card issuers and financial institutions
             'credit card company', 'credit card issuer', 'credit card provider',
             'credit card business', 'credit card services', 'credit card processing',
             'lending services', 'consumer lending', 'asset management', 

--- a/utils/islamic_screening.py
+++ b/utils/islamic_screening.py
@@ -73,6 +73,7 @@ def check_business_practices(info):
         'financial services': [
             'commercial bank', 'investment bank', 'mortgage', 'credit services',
             'credit card company', 'credit card issuer', 'credit card provider',
+            'credit card business', 'credit card services', 'credit card processing',
             'lending services', 'consumer lending', 'asset management', 
             'capital markets', 'insurance', 'investment brokerage', 
             'wealth management', 'retail banking', 'corporate banking', 


### PR DESCRIPTION
## Summary
• Fixed false positive where AAPL was incorrectly marked as non-compliant due to overly broad financial services keyword matching
• Updated "credit card" keyword to be more specific: "credit card company", "credit card issuer", "credit card provider"
• AAPL now correctly shows as business compliant since it's a technology company that offers Apple Card as a partnership product, not a credit card issuer

## Test plan
- [x] Verified AAPL business compliance check returns `True` after fix
- [x] Confirmed keyword matching is more precise for actual financial institutions
- [x] Tested via Streamlit app showing AAPL as "✓ Shariah Compliant"

🤖 Generated with [Claude Code](https://claude.ai/code)